### PR TITLE
Refactoring the XOAUTH2 authenticator

### DIFF
--- a/geronimo-javamail_1.6/geronimo-javamail_1.6_provider/pom.xml
+++ b/geronimo-javamail_1.6/geronimo-javamail_1.6_provider/pom.xml
@@ -343,8 +343,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>6</source>
-                    <target>6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-javamail_1.6/geronimo-javamail_1.6_provider/src/main/java/org/apache/geronimo/javamail/authentication/AuthenticatorFactory.java
+++ b/geronimo-javamail_1.6/geronimo-javamail_1.6_provider/src/main/java/org/apache/geronimo/javamail/authentication/AuthenticatorFactory.java
@@ -75,8 +75,7 @@ public class AuthenticatorFactory {
 
                 if (saslMechanisms != null && saslMechanisms.contains(AUTHENTICATION_XOAUTH2)) {
                     authenticatorClass = Class.forName("org.apache.geronimo.javamail.authentication.XOAUTH2Authenticator");
-                    XOAUTH2Authenticator.init();
-                }else{
+                } else {
                     authenticatorClass = Class.forName("org.apache.geronimo.javamail.authentication.SASLAuthenticator");
                 }
 

--- a/geronimo-javamail_1.6/geronimo-javamail_1.6_provider/src/main/java/org/apache/geronimo/javamail/authentication/XOAUTH2Authenticator.java
+++ b/geronimo-javamail_1.6/geronimo-javamail_1.6_provider/src/main/java/org/apache/geronimo/javamail/authentication/XOAUTH2Authenticator.java
@@ -18,53 +18,16 @@
 package org.apache.geronimo.javamail.authentication;
 
 import javax.mail.MessagingException;
-import javax.security.auth.callback.Callback;
-import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.callback.NameCallback;
-import javax.security.auth.callback.PasswordCallback;
-import javax.security.sasl.RealmCallback;
-import javax.security.sasl.RealmChoiceCallback;
-import java.io.UnsupportedEncodingException;
-import java.security.Provider;
-import java.security.Security;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
-public class XOAUTH2Authenticator implements ClientAuthenticator, CallbackHandler  {
+public class XOAUTH2Authenticator implements ClientAuthenticator {
 
-    //The realm we're authenticating within
-    protected String realm;
     //The user we're authenticating
     protected String username;
     //The user's password (the "shared secret")
     protected String password;
     protected boolean complete = false;
-    private static final String SECURITY_PROVIDER = "JavaMail-OAuth2";
-    private static final String CLIENT_FACTORY_NAME = "SaslClientFactory.XOAUTH2";
-
-    /**
-     * XOAUTH2 SASL Mechanism provider
-     */
-    static class Oauth2Provider extends Provider {
-        private static final long serialVersionUID = 1L;
-        public Oauth2Provider() {
-            super(SECURITY_PROVIDER, 1.0, "XOAUTH2 SASL Mechanism");
-            put(CLIENT_FACTORY_NAME, XOAUTH2Authenticator.class.getName());
-        }
-    }
-
-    /**
-     * Initialize OAUTH2 provider if there isn't one already.
-     * If the operation is not allowed we don't enforce it.
-     */
-    public static void init() {
-        try {
-            if (Security.getProvider(SECURITY_PROVIDER) == null) {
-                Security.addProvider(new Oauth2Provider());
-            }
-        } catch (SecurityException ex) {
-            //We don't enforce it.
-        }
-    }
 
     /**
      * Main constructor.
@@ -74,7 +37,6 @@ public class XOAUTH2Authenticator implements ClientAuthenticator, CallbackHandle
      */
     public XOAUTH2Authenticator(String[] mechanisms, Properties properties, String protocol, String host, String realm,
                                 String authorizationID, String username, String password) throws MessagingException {
-        this.realm = realm;
         this.username = username;
         this.password = password;
     }
@@ -115,94 +77,21 @@ public class XOAUTH2Authenticator implements ClientAuthenticator, CallbackHandle
      * @return A formatted challenge response, as an array of bytes.
      * @throws MessagingException
      */
-    public byte[] evaluateChallenge(byte[] challenge) throws MessagingException {
-        // for an initial response challenge, there's no challenge date.  The SASL
-        // client still expects a byte array argument.
-        if (challenge == null) {
-            challenge = new byte[0];
-        }
-
+    public byte[] evaluateChallenge(final byte[] challenge) {
         if (complete) {
             return new byte[0];
-        } else {
-            try {
-                final NameCallback userName = new NameCallback("User name:");
-                final PasswordCallback token = new PasswordCallback("OAuth token:", false);
-                this.handle(new Callback[] { userName, token });
-                final String resp = "user=" + userName.getName() + "\001auth=Bearer " + new String(token.getPassword()) + "\001\001";
-                byte[] response;
-
-                try {
-                    response = resp.getBytes("utf-8");
-                } catch (UnsupportedEncodingException ex) {
-                    response = getBytes(resp);
-                }
-
-                complete = true;
-                return response;
-            } catch (Exception e) {
-                throw new MessagingException("Error XOAUTH2 challenge", e);
-            }
         }
-    }
 
-    private byte[] getBytes(String s) {
-        final char[] chars = s.toCharArray();
-        final int size = chars.length;
-        final byte[] bytes = new byte[size];
+        final String response = new StringBuilder()
+                .append("user=")
+                .append(this.username)
+                .append("\001auth=Bearer ")
+                .append(this.password)
+                .append("\001\001")
+                .toString();
 
-        for (int i = 0; i < size; ) {
-            bytes[i] = (byte) chars[i++];
-        }
-        return bytes;
-    }
 
-    public void handle(Callback[] callBacks) {
-        for (int i = 0; i < callBacks.length; i++) {
-            Callback callBack = callBacks[i];
-            // requesting the user name
-            if (callBack instanceof NameCallback) {
-                ((NameCallback)callBack).setName(username);
-            }
-            // need the password
-            else if (callBack instanceof PasswordCallback) {
-
-                ((PasswordCallback)callBack).setPassword(password.toCharArray());
-            }
-            // direct request for the realm information
-            else if (callBack instanceof RealmCallback) {
-                RealmCallback realmCallback = (RealmCallback)callBack;
-                // we might not have a realm, so use the default from the
-                // callback item
-                if (realm == null) {
-                    realmCallback.setText(realmCallback.getDefaultText());
-                }
-                else {
-                    realmCallback.setText(realm);
-                }
-            }
-            // asked to select the realm information from a list
-            else if (callBack instanceof RealmChoiceCallback) {
-                RealmChoiceCallback realmCallback = (RealmChoiceCallback)callBack;
-                // if we don't have a realm, just tell it to use the default
-                if (realm == null) {
-                    realmCallback.setSelectedIndex(realmCallback.getDefaultChoice());
-                }
-                else {
-                    // locate our configured one in the list
-                    String[] choices = realmCallback.getChoices();
-
-                    for (int j = 0; j < choices.length; j++) {
-                        // set the index to any match and get out of here.
-                        if (choices[j].equals(realm)) {
-                            realmCallback.setSelectedIndex(j);
-                            break;
-                        }
-                    }
-                    // NB:  If there was no match, we don't set anything.
-                    // this should cause an authentication failure.
-                }
-            }
-        }
+        complete = true;
+        return response.getBytes(StandardCharsets.UTF_8);
     }
 }


### PR DESCRIPTION
This refactoring should greatly simplify the XOAUTH2 authenticator. The specific changes:

* Don't route the response created in evaluateChallenge through a callback handler. We already have the username and password as fields.
* Don't implement callback handler, nothing else in the codebase calls it
* Use StandardCharsets.UTF_8 for the String to byte[] conversion. The stops the exception being thrown, so the manual conversion to a byte[] is no longer needed as a fallback. This requires and update to Java 7, but I think that is reasonable.
* Build the response with a StringBuilder - this handles stuff like char[] to String conversion, and looks a lot neater.
* Remove the Provider stuff (what did it do?)
* No need to hold the realm (we don't use it)

Further improvements (to be considered):

* Rather than hardcode the class names, we could enable a mechanism where the user could provide their own in the servers lib folder, which probably would have made this much easier.